### PR TITLE
Añadir estado entregado a la orden

### DIFF
--- a/src/main/java/plazoleta/adapters/driven/jpa/msql/adapter/OrderAdapter.java
+++ b/src/main/java/plazoleta/adapters/driven/jpa/msql/adapter/OrderAdapter.java
@@ -120,7 +120,7 @@ public class OrderAdapter implements IOrderPersistencePort {
     private boolean isOrderInProcess (Optional<OrderEntity> orderEntity, String process) {
         return orderEntity.isPresent() && Objects.equals(orderEntity.get().getState(), process);
     }
-    public UserEntity getClientDetails(Optional<OrderEntity> orderEntity, String auth) {
+    private UserEntity getClientDetails(Optional<OrderEntity> orderEntity, String auth) {
         return externalApiConsumption.getRolByIdUser(orderEntity.get().getUserId(), auth);
     }
     private void updateOrderState(Optional<OrderEntity> orderEntity, String newState) {

--- a/src/main/java/plazoleta/adapters/driven/jpa/msql/adapter/PlateAdapter.java
+++ b/src/main/java/plazoleta/adapters/driven/jpa/msql/adapter/PlateAdapter.java
@@ -5,7 +5,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import plazoleta.adapters.driven.jpa.msql.entity.plate.PlateEntity;
 import plazoleta.adapters.driven.jpa.msql.entity.restaurant.RestaurantEntity;
-import plazoleta.adapters.driven.jpa.msql.exception.ErrorAccessModifi;
+import plazoleta.adapters.driven.jpa.msql.exception.ErrorAccessModified;
 import plazoleta.adapters.driven.jpa.msql.exception.ErrorBaseDatos;
 import plazoleta.adapters.driven.jpa.msql.exception.ProductNotFount;
 import plazoleta.adapters.driven.jpa.msql.mapper.IPlateEntityMapper;
@@ -44,7 +44,7 @@ public class PlateAdapter implements IPlatePersistencePort {
     @Override
     public Plate update(Plate plate, int id, int idAutenticado) {
         if (accessModified(plate, idAutenticado)) {
-            throw new ErrorAccessModifi("Solo el propietario del restaurante puede modificar");
+            throw new ErrorAccessModified("Solo el propietario del restaurante puede modificar");
         }
         try {
             PlateEntity plateEntity = plateRepositoryJPA.findById(id).get();

--- a/src/main/java/plazoleta/adapters/driven/jpa/msql/exception/ErrorAccessModifi.java
+++ b/src/main/java/plazoleta/adapters/driven/jpa/msql/exception/ErrorAccessModifi.java
@@ -1,7 +1,0 @@
-package plazoleta.adapters.driven.jpa.msql.exception;
-
-public class ErrorAccessModifi extends RuntimeException{
-    public ErrorAccessModifi(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/plazoleta/adapters/driven/jpa/msql/exception/ErrorAccessModified.java
+++ b/src/main/java/plazoleta/adapters/driven/jpa/msql/exception/ErrorAccessModified.java
@@ -1,0 +1,7 @@
+package plazoleta.adapters.driven.jpa.msql.exception;
+
+public class ErrorAccessModified extends RuntimeException{
+    public ErrorAccessModified(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/plazoleta/adapters/driving/http/controller/OrderRestController.java
+++ b/src/main/java/plazoleta/adapters/driving/http/controller/OrderRestController.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import plazoleta.adapters.driven.jpa.msql.entity.restaurant.UserEntity;
 import plazoleta.adapters.driven.jpa.msql.utils.consumer.ExternalApiConsumption;
+import plazoleta.adapters.driving.http.dto.request.order.OrderStateModificationDTO;
 import plazoleta.adapters.driving.http.utils.JwtService.JwtTokenValidator;
 import plazoleta.adapters.driving.http.dto.request.order.AddOrderRequest;
 import plazoleta.adapters.driving.http.exception.ErrorAccess;
@@ -70,5 +71,14 @@ public class OrderRestController {
         String auth = token.substring(7);
         int idAuthenticated = jwtTokenValidator.getUserIdFromToken(auth);
         return new ResponseEntity<>(orderServicePort.readyToDelivery(idAuthenticated, id, orderRequest, auth), HttpStatus.OK);
+    }
+
+    @PutMapping("/{id}/deliver-order")
+    public ResponseEntity<String> deliverOrder (@PathVariable int id,
+                                                @RequestBody OrderStateModificationDTO orderRequest,
+                                                @RequestHeader("Authorization") String token) {
+        String auth = token.substring(7);
+        int idAuthenticated = jwtTokenValidator.getUserIdFromToken(auth);
+        return new ResponseEntity<>(orderServicePort.deliveryOrder(idAuthenticated, id, orderRequest, auth), HttpStatus.OK);
     }
 }

--- a/src/main/java/plazoleta/adapters/driving/http/dto/request/order/OrderStateModificationDTO.java
+++ b/src/main/java/plazoleta/adapters/driving/http/dto/request/order/OrderStateModificationDTO.java
@@ -1,0 +1,12 @@
+package plazoleta.adapters.driving.http.dto.request.order;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class OrderStateModificationDTO {
+    private String pin;
+    private String productId;
+    private String action;
+}

--- a/src/main/java/plazoleta/adapters/driving/http/dto/request/order/OrderStateModificationDTO.java
+++ b/src/main/java/plazoleta/adapters/driving/http/dto/request/order/OrderStateModificationDTO.java
@@ -2,9 +2,11 @@ package plazoleta.adapters.driving.http.dto.request.order;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @AllArgsConstructor
+@NoArgsConstructor
 public class OrderStateModificationDTO {
     private String pin;
     private String productId;

--- a/src/main/java/plazoleta/config/exceptionhandler/ControllerAdvisor.java
+++ b/src/main/java/plazoleta/config/exceptionhandler/ControllerAdvisor.java
@@ -11,10 +11,9 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
-import plazoleta.adapters.driven.jpa.msql.exception.ErrorAccessModifi;
+import plazoleta.adapters.driven.jpa.msql.exception.ErrorAccessModified;
 import plazoleta.adapters.driven.jpa.msql.exception.ErrorBaseDatos;
 import plazoleta.adapters.driven.jpa.msql.exception.ProductNotFount;
-import plazoleta.adapters.driving.http.controller.OrderRestController;
 import plazoleta.adapters.driving.http.exception.ErrorAccess;
 import plazoleta.domain.exception.ExceptionValid;
 
@@ -34,8 +33,8 @@ public class ControllerAdvisor extends ResponseEntityExceptionHandler {
                 ));
     }
 
-    @ExceptionHandler(ErrorAccessModifi.class)
-    public ResponseEntity<ExceptionResponse> handleErrorAccessModify(ErrorAccessModifi exception) {
+    @ExceptionHandler(ErrorAccessModified.class)
+    public ResponseEntity<ExceptionResponse> handleErrorAccessModify(ErrorAccessModified exception) {
         return ResponseEntity.badRequest().body(new ExceptionResponse
                 (String.format(exception.getMessage()),
                         HttpStatus.BAD_REQUEST.toString(), LocalDateTime.now()

--- a/src/main/java/plazoleta/domain/api/IOrderServicePort.java
+++ b/src/main/java/plazoleta/domain/api/IOrderServicePort.java
@@ -2,6 +2,7 @@ package plazoleta.domain.api;
 
 import plazoleta.adapters.driven.jpa.msql.entity.restaurant.UserEntity;
 import plazoleta.adapters.driving.http.dto.request.order.AddOrderRequest;
+import plazoleta.adapters.driving.http.dto.request.order.OrderStateModificationDTO;
 import plazoleta.domain.model.pedido.Order;
 
 import java.util.List;
@@ -9,7 +10,7 @@ import java.util.List;
 public interface IOrderServicePort {
     Order create (Order order, int idAuthUser, UserEntity infoChef);
     List<Order> getOrderByState(String state, int page, int size, int idAuthenticated);
-
     Order takeOrder(int idAuthenticated, int idOrder, AddOrderRequest orderRequest);
     String readyToDelivery(int idAuthenticated, int id, AddOrderRequest orderRequest, String auth);
+    String deliveryOrder(int idAuthenticated, int id, OrderStateModificationDTO orderRequest, String auth);
 }

--- a/src/main/java/plazoleta/domain/api/useCase/OrderCaseUse.java
+++ b/src/main/java/plazoleta/domain/api/useCase/OrderCaseUse.java
@@ -3,6 +3,7 @@ package plazoleta.domain.api.useCase;
 import plazoleta.adapters.driven.jpa.msql.entity.order.OrderEntity;
 import plazoleta.adapters.driven.jpa.msql.entity.restaurant.UserEntity;
 import plazoleta.adapters.driving.http.dto.request.order.AddOrderRequest;
+import plazoleta.adapters.driving.http.dto.request.order.OrderStateModificationDTO;
 import plazoleta.domain.api.IOrderServicePort;
 import plazoleta.domain.exception.ExceptionValid;
 import plazoleta.domain.model.pedido.Order;
@@ -54,6 +55,11 @@ public class OrderCaseUse implements IOrderServicePort {
     @Override
     public String readyToDelivery(int idAuthenticated, int id, AddOrderRequest orderRequest, String auth) {
         return orderPersistencePort.readyToDelivery(idAuthenticated, id, orderRequest, auth);
+    }
+
+    @Override
+    public String deliveryOrder(int idAuthenticated, int id, OrderStateModificationDTO orderRequest, String auth) {
+        return orderPersistencePort.deliveryOrder(idAuthenticated, id, orderRequest, auth);
     }
 
 }

--- a/src/main/java/plazoleta/domain/spi/IOrderPersistencePort.java
+++ b/src/main/java/plazoleta/domain/spi/IOrderPersistencePort.java
@@ -1,6 +1,7 @@
 package plazoleta.domain.spi;
 
 import plazoleta.adapters.driving.http.dto.request.order.AddOrderRequest;
+import plazoleta.adapters.driving.http.dto.request.order.OrderStateModificationDTO;
 import plazoleta.domain.model.pedido.Order;
 
 import java.util.List;
@@ -8,7 +9,7 @@ import java.util.List;
 public interface IOrderPersistencePort {
     Order save(Order order);
     List<Order> getOrderByState (String state, int page, int size, int idAuthenticated);
-
     Order takeOrder (int idAuthenticated, int idOrder, AddOrderRequest orderRequest);
     String readyToDelivery(int idAuthenticated, int id, AddOrderRequest orderRequest, String auth);
+    String deliveryOrder(int idAuthenticated, int id, OrderStateModificationDTO orderRequest, String auth);
 }

--- a/src/test/java/plazoleta/adapters/driven/jpa/msql/adapter/OrderAdapterTest.java
+++ b/src/test/java/plazoleta/adapters/driven/jpa/msql/adapter/OrderAdapterTest.java
@@ -10,8 +10,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import plazoleta.adapters.driven.jpa.msql.entity.order.OrderEntity;
 import plazoleta.adapters.driven.jpa.msql.entity.restaurant.RestaurantEntity;
 import plazoleta.adapters.driven.jpa.msql.entity.restaurant.UserEntity;
-import plazoleta.adapters.driven.jpa.msql.exception.ErrorAccessModifi;
-import plazoleta.adapters.driven.jpa.msql.exception.ErrorBaseDatos;
+import plazoleta.adapters.driven.jpa.msql.exception.ErrorAccessModified;
 import plazoleta.adapters.driven.jpa.msql.mapper.IOrderEntityMapper;
 import plazoleta.adapters.driven.jpa.msql.repository.IOrderRepositoryJPA;
 import plazoleta.adapters.driven.jpa.msql.repository.IRestaurantRepositoryJPA;
@@ -74,7 +73,7 @@ class OrderAdapterTest {
         OrderEntity orderEntity = new OrderEntity();
         orderEntity.setState("pendiente");
         when(orderRepositoryJPA.findByUserId(33)).thenReturn(Optional.of(orderEntity));
-        assertThrows(ErrorAccessModifi.class, () -> orderAdapter.save(order));
+        assertThrows(ErrorAccessModified.class, () -> orderAdapter.save(order));
     }
 
 

--- a/src/test/java/plazoleta/adapters/driven/jpa/msql/adapter/OrderAdapterTest.java
+++ b/src/test/java/plazoleta/adapters/driven/jpa/msql/adapter/OrderAdapterTest.java
@@ -11,11 +11,13 @@ import plazoleta.adapters.driven.jpa.msql.entity.order.OrderEntity;
 import plazoleta.adapters.driven.jpa.msql.entity.restaurant.RestaurantEntity;
 import plazoleta.adapters.driven.jpa.msql.entity.restaurant.UserEntity;
 import plazoleta.adapters.driven.jpa.msql.exception.ErrorAccessModified;
+import plazoleta.adapters.driven.jpa.msql.exception.ProductNotFount;
 import plazoleta.adapters.driven.jpa.msql.mapper.IOrderEntityMapper;
 import plazoleta.adapters.driven.jpa.msql.repository.IOrderRepositoryJPA;
 import plazoleta.adapters.driven.jpa.msql.repository.IRestaurantRepositoryJPA;
 import plazoleta.adapters.driven.jpa.msql.utils.consumer.ExternalApiConsumption;
 import plazoleta.adapters.driving.http.dto.request.order.AddOrderRequest;
+import plazoleta.adapters.driving.http.dto.request.order.OrderStateModificationDTO;
 import plazoleta.domain.model.pedido.Order;
 
 import java.time.LocalDate;
@@ -26,7 +28,8 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
+import static plazoleta.adapters.driven.jpa.msql.utils.constants.ConstanstUtils.STAGE_PRODUCT_NOT_PREPARING;
 
 @ExtendWith(MockitoExtension.class)
 class OrderAdapterTest {
@@ -200,5 +203,77 @@ class OrderAdapterTest {
 
         // Assert
         Assertions.assertNotNull(result);
+    }
+
+    @Test
+    void deliveryOrder_SuccessfulDelivery() {
+        // Arrange
+        int idAuthenticated = 1;
+        int id = 2;
+        String auth = "authToken";
+        OrderStateModificationDTO orderRequest = new OrderStateModificationDTO();
+        orderRequest.setPin("1234");
+
+        OrderEntity orderEntity = new OrderEntity();
+        orderEntity.setPin("1234");
+        orderEntity.setState("listo");
+
+        when(orderRepositoryJPA.findById(id)).thenReturn(Optional.of(orderEntity));
+
+        // Act
+        String result = orderAdapter.deliveryOrder(idAuthenticated, id, orderRequest, auth);
+
+        // Assert
+        verify(orderRepositoryJPA).findById(id);
+        verify(orderRepositoryJPA).save(orderEntity);
+        assertEquals("El estado de producto ya fue cambiado a entregado", result);
+        assertEquals("entregado", orderEntity.getState());
+    }
+
+    @Test
+    void deliveryOrder_PinNotValid() {
+        // Arrange
+        int idAuthenticated = 1;
+        int id = 2;
+        String auth = "authToken";
+        OrderStateModificationDTO orderRequest = new OrderStateModificationDTO();
+        orderRequest.setPin("0000"); // PIN incorrecto
+
+        OrderEntity orderEntity = new OrderEntity();
+        orderEntity.setPin("1234");
+        orderEntity.setState("listo");
+
+        when(orderRepositoryJPA.findById(id)).thenReturn(Optional.of(orderEntity));
+
+        // Act & Assert
+        assertThrows(ProductNotFount.class, () -> {
+            orderAdapter.deliveryOrder(idAuthenticated, id, orderRequest, auth);
+        });
+        verify(orderRepositoryJPA).findById(id);
+        verify(orderRepositoryJPA, never()).save(orderEntity);
+    }
+
+    @Test
+    void deliveryOrder_OrderNotInReadyState() {
+        // Arrange
+        int idAuthenticated = 1;
+        int id = 2;
+        String auth = "authToken";
+        OrderStateModificationDTO orderRequest = new OrderStateModificationDTO();
+        orderRequest.setPin("1234");
+
+        OrderEntity orderEntity = new OrderEntity();
+        orderEntity.setPin("1234");
+        orderEntity.setState("preparando"); // La orden no está lista
+
+        when(orderRepositoryJPA.findById(id)).thenReturn(Optional.of(orderEntity));
+
+        // Act
+        String result = orderAdapter.deliveryOrder(idAuthenticated, id, orderRequest, auth);
+
+        // Assert
+        verify(orderRepositoryJPA).findById(id);
+        verify(orderRepositoryJPA, never()).save(orderEntity);
+        assertEquals(STAGE_PRODUCT_NOT_PREPARING, result);
     }
 }

--- a/src/test/java/plazoleta/adapters/driving/http/controller/OrderRestControllerTest.java
+++ b/src/test/java/plazoleta/adapters/driving/http/controller/OrderRestControllerTest.java
@@ -15,6 +15,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import plazoleta.adapters.driven.jpa.msql.entity.restaurant.UserEntity;
 import plazoleta.adapters.driven.jpa.msql.utils.consumer.ExternalApiConsumption;
+import plazoleta.adapters.driving.http.dto.request.order.OrderStateModificationDTO;
 import plazoleta.adapters.driving.http.utils.JwtService.JwtTokenValidator;
 import plazoleta.adapters.driving.http.dto.request.order.AddOrderRequest;
 import plazoleta.adapters.driving.http.mapper.IOrderRequestMapper;
@@ -26,6 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -91,5 +93,25 @@ class OrderRestControllerTest {
                         .header(HttpHeaders.AUTHORIZATION, "Bearer TOKEN_DE_PRUEBA")
                 )
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    void deliverOrder() throws Exception {
+        int id = 1;
+        String token = "Bearer mockToken";
+        String expected = "El estado de producto ya fue cambiado a entregado";
+        OrderStateModificationDTO orderRequest = new OrderStateModificationDTO();
+
+        when(jwtTokenValidator.getUserIdFromToken("mockToken")).thenReturn(1);
+        when(orderServicePort.deliveryOrder(1, id, orderRequest, "mockToken")).thenReturn(expected);
+
+        // Act
+        ResponseEntity<String> response = orderRestController.deliverOrder(id, orderRequest, token);
+
+        // Assert
+        verify(jwtTokenValidator).getUserIdFromToken("mockToken");
+        verify(orderServicePort).deliveryOrder(1, id, orderRequest, "mockToken");
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(expected, response.getBody());
     }
 }


### PR DESCRIPTION
### Entregar pedido (Marcarlo como entregado)

**Descripción** :   Yo como empleado de un restaurante necesito marcar como entregado un pedido para poder cerrar el ciclo del mismo y concentrarme en otros pedidos

1. Sólo los pedidos que están en estado "Listo" pueden pasar a estado "entregado"
2. Ningún pedido en estado "entregado" puede ser modificado a cualquier estado diferente de "Listo".
3. Par apoder cambiar al estado "entregado" el empleado debe digitar el pin de seguridad que le fue enviado al cliente para reclamar su pedido.
```

curl --location --request PUT 'http://localhost:8098/order/57/deliver-order' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c3VhcmlvaWQzQGdtYWlsLmNvbSIsInVzZXJJZCI6MjYsInJvbCI6InRyYWJhamFkb3IiLCJpYXQiOjE3MTMzMjE2OTUsImV4cCI6MTcxMzMyMzEzNX0.qbXDQCbFyCiSlZUnT0psauDEX9rVVVc9GJ1Nx1OWDlM' \
--header 'Cookie: JSESSIONID=3950671FF25177B639C7CF7E7CED4E6C' \
--data '{
    "pin": "7339",
    "productId": "56",
    "action": "entregado"
}'
```