### PR TITLE
cancelar orden

### DIFF
--- a/src/main/java/plazoleta/adapters/driving/http/controller/OrderRestController.java
+++ b/src/main/java/plazoleta/adapters/driving/http/controller/OrderRestController.java
@@ -81,4 +81,15 @@ public class OrderRestController {
         int idAuthenticated = jwtTokenValidator.getUserIdFromToken(auth);
         return new ResponseEntity<>(orderServicePort.deliveryOrder(idAuthenticated, id, orderRequest, auth), HttpStatus.OK);
     }
+
+    @PutMapping("/{id}/cancel-order")
+    public ResponseEntity<String> cancelOrder (@PathVariable int id,
+                                                @RequestHeader("Authorization") String token) {
+        String auth = token.substring(7);
+        int idAuthenticated = jwtTokenValidator.getUserIdFromToken(auth);
+        return new ResponseEntity<>(orderServicePort.cancelOrder(idAuthenticated, id), HttpStatus.OK);
+    }
+
+
+
 }

--- a/src/main/java/plazoleta/config/Auth/SecurityConfig.java
+++ b/src/main/java/plazoleta/config/Auth/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST,"/order/create").hasAuthority("cliente")
                         .requestMatchers(HttpMethod.GET, "/order/get-all").hasAuthority("trabajador")
                         .requestMatchers(HttpMethod.PUT, "/order/update/{id}").hasAuthority("trabajador")
-
+                        .requestMatchers(HttpMethod.PUT, "order/{id}/deliver-order").hasAuthority("trabajador")
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(new JwtTokenValidationFilter(tokenValidator), UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/plazoleta/domain/api/IOrderServicePort.java
+++ b/src/main/java/plazoleta/domain/api/IOrderServicePort.java
@@ -13,4 +13,5 @@ public interface IOrderServicePort {
     Order takeOrder(int idAuthenticated, int idOrder, AddOrderRequest orderRequest);
     String readyToDelivery(int idAuthenticated, int id, AddOrderRequest orderRequest, String auth);
     String deliveryOrder(int idAuthenticated, int id, OrderStateModificationDTO orderRequest, String auth);
+    String cancelOrder(int idAuthenticated, int id);
 }

--- a/src/main/java/plazoleta/domain/api/useCase/OrderCaseUse.java
+++ b/src/main/java/plazoleta/domain/api/useCase/OrderCaseUse.java
@@ -62,4 +62,9 @@ public class OrderCaseUse implements IOrderServicePort {
         return orderPersistencePort.deliveryOrder(idAuthenticated, id, orderRequest, auth);
     }
 
+    @Override
+    public String cancelOrder(int idAuthenticated, int id) {
+        return orderPersistencePort.cancelOrder(idAuthenticated, id);
+    }
+
 }

--- a/src/main/java/plazoleta/domain/spi/IOrderPersistencePort.java
+++ b/src/main/java/plazoleta/domain/spi/IOrderPersistencePort.java
@@ -12,4 +12,5 @@ public interface IOrderPersistencePort {
     Order takeOrder (int idAuthenticated, int idOrder, AddOrderRequest orderRequest);
     String readyToDelivery(int idAuthenticated, int id, AddOrderRequest orderRequest, String auth);
     String deliveryOrder(int idAuthenticated, int id, OrderStateModificationDTO orderRequest, String auth);
+    String cancelOrder(int idAuthenticated, int id);
 }

--- a/src/test/java/plazoleta/adapters/driving/http/controller/OrderRestControllerTest.java
+++ b/src/test/java/plazoleta/adapters/driving/http/controller/OrderRestControllerTest.java
@@ -114,4 +114,23 @@ class OrderRestControllerTest {
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(expected, response.getBody());
     }
+
+    @Test
+    void cancelOrder_SuccessfulCancellation() {
+        // Arrange
+        int id = 1;
+        String token = "Bearer mockToken";
+
+        when(jwtTokenValidator.getUserIdFromToken("mockToken")).thenReturn(1);
+        when(orderServicePort.cancelOrder(1, id)).thenReturn("Su orden fue cancelada correctamente");
+
+        // Act
+        ResponseEntity<String> response = orderRestController.cancelOrder(id, token);
+
+        // Assert
+        verify(jwtTokenValidator).getUserIdFromToken("mockToken");
+        verify(orderServicePort).cancelOrder(1, id);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("Su orden fue cancelada correctamente", response.getBody());
+    }
 }


### PR DESCRIPTION
### Cancelar orden

1. Sólo se pueden cancelar pedidos que se encuentren en estado "Pendiente"
2, Si el estado del pedido que tratan de cancelar es diferente a "Pendiente", se le debe notificar al usuario: "Lo sentimos, tu pedido ya está en preparación y no puede cancelarse"

```
curl --location --request PUT 'http://localhost:8098/order/57/cancel-order' \
--header 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJjbGllbnRlM0BnbWFpbC5jb20iLCJ1c2VySWQiOjM1LCJyb2wiOiJjbGllbnRlIiwiaWF0IjoxNzEzMzI1MzYzLCJleHAiOjE3MTMzMjY4MDN9.UPnkw4-Lc9t9B-_9RaGohTuDlWsFaD5tz_9pGiO305k' \
--header 'Cookie: JSESSIONID=3950671FF25177B639C7CF7E7CED4E6C'
```